### PR TITLE
Auth with storing token as plain text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 build
 .cache
-
+.token
 html
 latex

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,7 +1,32 @@
+include(FetchContent)
+FetchContent_Declare(
+   httplib
+   GIT_REPOSITORY https://github.com/yhirose/cpp-httplib
+   GIT_TAG v0.28.0
+)
+FetchContent_MakeAvailable(httplib)
+
+FetchContent_Declare(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v3.11.3
+)
+FetchContent_MakeAvailable(nlohmann_json)
+
 add_library(teams_lib STATIC
     src/Test.cpp
 )
 
 target_include_directories( teams_lib
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+find_package(OpenSSL REQUIRED)
+
+target_link_libraries(teams_lib
+    PUBLIC
+        OpenSSL::SSL
+        OpenSSL::Crypto
+        httplib
+        nlohmann_json::nlohmann_json
 )

--- a/lib/include/teams_lib/auth/DeviceCodeCredential.hpp
+++ b/lib/include/teams_lib/auth/DeviceCodeCredential.hpp
@@ -1,12 +1,11 @@
 #pragma once
 #include <string>
+#include <teams_lib/common.hpp>
 
 namespace teams {
 namespace priv {
 
 class DeviceCodeCredential {
-    using ID = std::string;
-
 public:
     DeviceCodeCredential(ID tenant_id, ID client_id)
         : tenant_id_{std::move(tenant_id)}, client_id_{std::move(client_id)} {}
@@ -15,8 +14,8 @@ public:
     const ID& client() const { return client_id_; }
 
 private:
-    std::string tenant_id_;
-    std::string client_id_;
+    ID tenant_id_;
+    ID client_id_;
 };
 
 }  // namespace priv

--- a/lib/include/teams_lib/auth/DeviceCodeCredential.hpp
+++ b/lib/include/teams_lib/auth/DeviceCodeCredential.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <string>
 #include <teams_lib/common.hpp>
 
 namespace teams {

--- a/lib/include/teams_lib/auth/DeviceCodeCredential.hpp
+++ b/lib/include/teams_lib/auth/DeviceCodeCredential.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include <string>
+
+namespace teams {
+namespace priv {
+
+class DeviceCodeCredential {
+    using ID = std::string;
+
+public:
+    DeviceCodeCredential(ID tenant_id, ID client_id)
+        : tenant_id_{std::move(tenant_id)}, client_id_{std::move(client_id)} {}
+
+    const ID& tenant() const { return tenant_id_; }
+    const ID& client() const { return client_id_; }
+
+private:
+    std::string tenant_id_;
+    std::string client_id_;
+};
+
+}  // namespace priv
+using DeviceCodeCredential = priv::DeviceCodeCredential;
+}  // namespace teams

--- a/lib/include/teams_lib/auth/DeviceTokenProvider.hpp
+++ b/lib/include/teams_lib/auth/DeviceTokenProvider.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <httplib.h>
+
+#include <nlohmann/json.hpp>
+#include <optional>
+
+#include "teams_lib/auth/TokenProvider.hpp"
+
+namespace teams {
+namespace priv {
+
+class DeviceTokenProvider : public TokenProvider<DeviceTokenProvider> {
+    friend TokenProvider;
+    using TokenProvider<DeviceTokenProvider>::credentials;
+    using TokenProvider<DeviceTokenProvider>::scopes;
+
+public:
+    DeviceTokenProvider(DeviceCodeCredential device_code_credential,
+                        std::string scopes)
+
+        : TokenProvider{std::move(device_code_credential), std::move(scopes)} {}
+
+private:
+    std::optional<Tokens> acquireTokensImpl() const {
+        httplib::Client cli("https://login.microsoftonline.com");
+
+        auto device_code_path = std::string("/" + credentials().tenant() +
+                                            "/oauth2/v2.0/devicecode");
+
+        auto device_params = httplib::Params{
+            {"client_id", credentials().client()}, {"scope", scopes()}};
+
+        auto device_res = cli.Post(device_code_path, device_params);
+
+        // TODO: add better error handling
+        if (!device_res) {
+            return std::nullopt;
+        }
+
+        auto device_code_resp = nlohmann::json::parse(device_res->body);
+
+        auto message = device_code_resp["message"].get<std::string>();
+        auto device_code = device_code_resp["device_code"].get<std::string>();
+        auto interval = device_code_resp["interval"].get<int>();
+
+        // Print out auth message
+        std::cout << message << "\n\n";
+
+        auto token_path =
+            std::string("/" + credentials().tenant() + "/oauth2/v2.0/token");
+
+        while (true) {
+            std::this_thread::sleep_for(std::chrono::seconds(interval));
+            httplib::Params token_params = {
+                {"grant_type", "device_code"},
+                {"client_id", credentials().client()},
+                {"device_code", device_code}};
+
+            auto token_res = cli.Post(token_path, token_params);
+
+            // TODO: Add checking if url is ok
+            if (!token_res) {
+                continue;
+            }
+
+            auto token_json = nlohmann::json::parse(token_res->body);
+
+            if (token_json.contains("error")) {
+                continue;
+            }
+
+            return Tokens{
+                .access_token = token_json["access_token"].get<Token>(),
+                .refresh_token = token_json["refresh_token"].get<Token>()};
+        }
+    }
+
+    std::optional<Tokens> acquireTokensSilentlyImpl(
+        const RefreshToken& refresh_token) const {
+        httplib::Client cli("https://login.microsoftonline.com");
+
+        auto refresh_path =
+            std::string("/" + credentials().tenant() + "/oauth2/v2.0/token");
+        auto refresh_header = httplib::Headers{
+            {"Content-Type", "application/x-www-form-urlencoded"}};
+
+        auto refresh_params =
+            httplib::Params{{"client_id", credentials().client()},
+                            {"scope", scopes()},
+                            {"refresh_token", refresh_token},
+                            {"grant_type", "refresh_token"}};
+
+        auto refresh_res =
+            cli.Post(refresh_path, refresh_header, refresh_params);
+
+        // TODO: add better error handling
+        if (!refresh_res) {
+            return std::nullopt;
+        }
+
+        auto refresh_resp = nlohmann::json::parse(refresh_res->body);
+
+        // TODO: add error
+        if (!refresh_resp.contains("access_token")) {
+            return std::nullopt;
+        }
+
+        auto tokens = Tokens{
+            .access_token = refresh_resp["access_token"].get<AccessToken>()};
+
+        if (refresh_resp.contains("refresh_token")) {
+            tokens.refresh_token =
+                refresh_resp["refresh_token"].get<RefreshToken>();
+        }
+
+        return tokens;
+    }
+};
+}  // namespace priv
+using DeviceTokenProvider = priv::DeviceTokenProvider;
+}  // namespace teams

--- a/lib/include/teams_lib/auth/DeviceTokenProvider.hpp
+++ b/lib/include/teams_lib/auth/DeviceTokenProvider.hpp
@@ -12,8 +12,6 @@ namespace priv {
 
 class DeviceTokenProvider : public TokenProvider<DeviceTokenProvider> {
     friend TokenProvider;
-    using TokenProvider<DeviceTokenProvider>::credentials;
-    using TokenProvider<DeviceTokenProvider>::scopes;
 
 public:
     DeviceTokenProvider(DeviceCodeCredential device_code_credential,
@@ -22,7 +20,7 @@ public:
         : TokenProvider{std::move(device_code_credential), std::move(scopes)} {}
 
 private:
-    std::optional<Tokens> acquireTokensImpl() const {
+    std::optional<Tokens> acquireImpl() const {
         httplib::Client cli("https://login.microsoftonline.com");
 
         auto device_code_path = std::string("/" + credentials().tenant() +
@@ -76,8 +74,7 @@ private:
         }
     }
 
-    std::optional<Tokens> acquireTokensSilentlyImpl(
-        const RefreshToken& refresh_token) const {
+    std::optional<Tokens> acquireSilentlyImpl(const RefreshToken& token) const {
         httplib::Client cli("https://login.microsoftonline.com");
 
         auto refresh_path =
@@ -88,7 +85,7 @@ private:
         auto refresh_params =
             httplib::Params{{"client_id", credentials().client()},
                             {"scope", scopes()},
-                            {"refresh_token", refresh_token},
+                            {"refresh_token", token},
                             {"grant_type", "refresh_token"}};
 
         auto refresh_res =
@@ -100,7 +97,6 @@ private:
         }
 
         auto refresh_resp = nlohmann::json::parse(refresh_res->body);
-
         // TODO: add error
         if (!refresh_resp.contains("access_token")) {
             return std::nullopt;
@@ -113,7 +109,6 @@ private:
             tokens.refresh_token =
                 refresh_resp["refresh_token"].get<RefreshToken>();
         }
-
         return tokens;
     }
 };

--- a/lib/include/teams_lib/auth/DeviceTokenProvider.hpp
+++ b/lib/include/teams_lib/auth/DeviceTokenProvider.hpp
@@ -23,46 +23,47 @@ private:
     std::optional<Tokens> acquireImpl() const {
         httplib::Client cli("https://login.microsoftonline.com");
 
-        auto device_code_path = std::string("/" + credentials().tenant() +
-                                            "/oauth2/v2.0/devicecode");
+        const auto device_code_path = std::string("/" + credentials().tenant() +
+                                                  "/oauth2/v2.0/devicecode");
 
-        auto device_params = httplib::Params{
+        const auto device_params = httplib::Params{
             {"client_id", credentials().client()}, {"scope", scopes()}};
 
-        auto device_res = cli.Post(device_code_path, device_params);
+        const auto device_res = cli.Post(device_code_path, device_params);
 
         // TODO: add better error handling
         if (!device_res) {
             return std::nullopt;
         }
 
-        auto device_code_resp = nlohmann::json::parse(device_res->body);
+        const auto device_code_resp = nlohmann::json::parse(device_res->body);
 
-        auto message = device_code_resp["message"].get<std::string>();
-        auto device_code = device_code_resp["device_code"].get<std::string>();
-        auto interval = device_code_resp["interval"].get<int>();
+        const auto message = device_code_resp["message"].get<std::string>();
+        const auto device_code =
+            device_code_resp["device_code"].get<std::string>();
+        const auto interval = device_code_resp["interval"].get<int>();
 
         // Print out auth message
         std::cout << message << "\n\n";
 
-        auto token_path =
+        const auto token_path =
             std::string("/" + credentials().tenant() + "/oauth2/v2.0/token");
 
         while (true) {
             std::this_thread::sleep_for(std::chrono::seconds(interval));
-            httplib::Params token_params = {
+            const httplib::Params token_params = {
                 {"grant_type", "device_code"},
                 {"client_id", credentials().client()},
                 {"device_code", device_code}};
 
-            auto token_res = cli.Post(token_path, token_params);
+            const auto token_res = cli.Post(token_path, token_params);
 
             // TODO: Add checking if url is ok
             if (!token_res) {
                 continue;
             }
 
-            auto token_json = nlohmann::json::parse(token_res->body);
+            const auto token_json = nlohmann::json::parse(token_res->body);
 
             if (token_json.contains("error")) {
                 continue;
@@ -77,18 +78,18 @@ private:
     std::optional<Tokens> acquireSilentlyImpl(const RefreshToken& token) const {
         httplib::Client cli("https://login.microsoftonline.com");
 
-        auto refresh_path =
+        const auto refresh_path =
             std::string("/" + credentials().tenant() + "/oauth2/v2.0/token");
-        auto refresh_header = httplib::Headers{
+        const auto refresh_header = httplib::Headers{
             {"Content-Type", "application/x-www-form-urlencoded"}};
 
-        auto refresh_params =
+        const auto refresh_params =
             httplib::Params{{"client_id", credentials().client()},
                             {"scope", scopes()},
                             {"refresh_token", token},
                             {"grant_type", "refresh_token"}};
 
-        auto refresh_res =
+        const auto refresh_res =
             cli.Post(refresh_path, refresh_header, refresh_params);
 
         // TODO: add better error handling
@@ -96,7 +97,7 @@ private:
             return std::nullopt;
         }
 
-        auto refresh_resp = nlohmann::json::parse(refresh_res->body);
+        const auto refresh_resp = nlohmann::json::parse(refresh_res->body);
         // TODO: add error
         if (!refresh_resp.contains("access_token")) {
             return std::nullopt;

--- a/lib/include/teams_lib/auth/PlainTextTokenStorage.hpp
+++ b/lib/include/teams_lib/auth/PlainTextTokenStorage.hpp
@@ -21,7 +21,7 @@ public:
           file_path_(std::move(file_path)) {}
 
 private:
-    std::optional<RefreshToken> loadRefreshTokenImpl() const {
+    std::optional<RefreshToken> loadImpl() const {
         std::ifstream file_handle(file_path_);
         if (!file_handle.is_open()) {
             return std::nullopt;
@@ -31,7 +31,7 @@ private:
     }
 
     // TODO: add status returning
-    void storeRefreshTokenImpl(const RefreshToken& token) const {
+    void storeImpl(const RefreshToken& token) const {
         std::ofstream file_handle(file_path_);
         if (file_handle.is_open()) {
             file_handle << token;

--- a/lib/include/teams_lib/auth/PlainTextTokenStorage.hpp
+++ b/lib/include/teams_lib/auth/PlainTextTokenStorage.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <httplib.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+#include "teams_lib/auth/TokenStorageProvider.hpp"
+namespace teams {
+namespace priv {
+
+class PlainTextTokenStorage
+    : public TokenStorageProvider<PlainTextTokenStorage> {
+    friend TokenStorageProvider;
+
+public:
+    PlainTextTokenStorage(std::filesystem::path file_path)
+        : TokenStorageProvider<PlainTextTokenStorage>(),
+          file_path_(std::move(file_path)) {}
+
+private:
+    std::optional<RefreshToken> loadRefreshTokenImpl() const {
+        std::ifstream file_handle(file_path_);
+        if (!file_handle.is_open()) {
+            return std::nullopt;
+            // throw std::runtime_error("Token file could not be opened");
+        }
+        return RefreshToken(std::istreambuf_iterator<char>{file_handle}, {});
+    }
+
+    // TODO: add status returning
+    void storeRefreshTokenImpl(const RefreshToken& token) const {
+        std::ofstream file_handle(file_path_);
+        if (file_handle.is_open()) {
+            file_handle << token;
+        } else {
+            std::cout << "[LOG] Unable to store token\n";
+            // throw std::runtime_error("Token file could not be opened");
+        }
+    }
+
+    std::filesystem::path file_path_;
+};
+}  // namespace priv
+using PlainTextTokenStorage = priv::PlainTextTokenStorage;
+}  // namespace teams

--- a/lib/include/teams_lib/auth/SessionManager.hpp
+++ b/lib/include/teams_lib/auth/SessionManager.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "teams_lib/common.hpp"
+#include <optional>
+#include <teams_lib/auth/Tokens.hpp>
+#include <teams_lib/common.hpp>
 
 namespace teams::priv {
 
@@ -23,43 +25,30 @@ public:
     }
 
 private:
-    void tryStoreRefreshToken(const RefreshToken& refresh_token) {
-        storage_provider_.storeRefreshToken(refresh_token);
+    void tryToStore(const std::optional<RefreshToken>& token) {
+        if (token) {
+            storage_provider_.store(token.value());
+        }
     }
 
-    bool tryAcquireTokensSilently() {
-        if (auto refresh_token = storage_provider_.loadRefreshToken()) {
-            if (auto tokens =
-                    provider_.acquireTokensSilently(refresh_token.value())) {
-                cached_token_ = tokens.value().access_token;
-
-                // try to store refresh token
-                if (tokens.value().refresh_token) {
-                    tryStoreRefreshToken(tokens.value().refresh_token.value());
-                }
-                return true;
-            }
+    // TODO: change to std::expected
+    std::optional<Tokens> tryToAcquireSilently() {
+        if (auto refresh_token = storage_provider_.load()) {
+            return provider_.acquireSilently(refresh_token.value());
         }
-        return false;
-    }
-    bool tryAcquireTokens() {
-        if (auto tokens = provider_.acquireTokens()) {
-            cached_token_ = tokens.value().access_token;
-            if (!tokens.value().refresh_token) {
-                std::cout << "[WARNING] NO REFRESH TOKEN\n";
-            }
-            tryStoreRefreshToken(tokens.value().refresh_token.value());
-            return true;
-        }
-        return false;
+        return std::nullopt;
     }
 
     void acquireTokens() {
-        if (tryAcquireTokensSilently()) {
-            return;
+        if (auto tokens = tryToAcquireSilently()) {
+            cached_token_ = tokens.value().access_token;
+            tryToStore(tokens.value().refresh_token);
+            return;  // tokens acquired
         }
-        if (tryAcquireTokens()) {
-            return;
+        if (auto tokens = provider_.acquire()) {
+            cached_token_ = tokens.value().access_token;
+            tryToStore(tokens.value().refresh_token);
+            return;  // tokens acquired
         }
         throw;
     }

--- a/lib/include/teams_lib/auth/SessionManager.hpp
+++ b/lib/include/teams_lib/auth/SessionManager.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "teams_lib/common.hpp"
+
+namespace teams::priv {
+
+template <typename TokenProvider, typename TokenStorageProvider>
+class SessionManager {
+public:
+    SessionManager(TokenProvider&& provider,
+                   TokenStorageProvider&& storage_provider)
+        : provider_{std::move(provider)},
+          storage_provider_{std::move(storage_provider)} {
+        acquireTokens();
+    }
+
+    constexpr void authorizeRequestHeader(HttpHeader& header) const {
+        header.emplace("Authorization", "Bearer " + cached_token_);
+    }
+
+    void authorizeClient(HttpClient& client) const {
+        client.set_bearer_token_auth(cached_token_);
+    }
+
+private:
+    void tryStoreRefreshToken(const RefreshToken& refresh_token) {
+        storage_provider_.storeRefreshToken(refresh_token);
+    }
+
+    bool tryAcquireTokensSilently() {
+        if (auto refresh_token = storage_provider_.loadRefreshToken()) {
+            if (auto tokens =
+                    provider_.acquireTokensSilently(refresh_token.value())) {
+                cached_token_ = tokens.value().access_token;
+
+                // try to store refresh token
+                if (tokens.value().refresh_token) {
+                    tryStoreRefreshToken(tokens.value().refresh_token.value());
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+    bool tryAcquireTokens() {
+        if (auto tokens = provider_.acquireTokens()) {
+            cached_token_ = tokens.value().access_token;
+            if (!tokens.value().refresh_token) {
+                std::cout << "[WARNING] NO REFRESH TOKEN\n";
+            }
+            tryStoreRefreshToken(tokens.value().refresh_token.value());
+            return true;
+        }
+        return false;
+    }
+
+    void acquireTokens() {
+        if (tryAcquireTokensSilently()) {
+            return;
+        }
+        if (tryAcquireTokens()) {
+            return;
+        }
+        throw;
+    }
+
+    TokenProvider provider_;
+    TokenStorageProvider storage_provider_;
+    AccessToken cached_token_;
+};
+}  // namespace teams::priv

--- a/lib/include/teams_lib/auth/TokenProvider.hpp
+++ b/lib/include/teams_lib/auth/TokenProvider.hpp
@@ -10,32 +10,30 @@ namespace teams::priv {
 template <typename DerivedProvider>
 class TokenProvider {
 public:
-    explicit TokenProvider(DeviceCodeCredential device_code_credential,
-                           std::string scopes)
-        : device_code_credential_{std::move(device_code_credential)},
+    explicit TokenProvider(DeviceCodeCredential credentials, Scopes scopes)
+        : device_code_credential_{std::move(credentials)},
           scopes_{std::move(scopes)} {};
 
     // TODO: change to std::expected on c++ version bump
-    std::optional<Tokens> acquireTokens() const {
-        return static_cast<const DerivedProvider*>(this)->acquireTokensImpl();
+    std::optional<Tokens> acquire() const {
+        return static_cast<const DerivedProvider*>(this)->acquireImpl();
     };
 
     // TODO: change to std::expected on c++ version bump
-    std::optional<Tokens> acquireTokensSilently(
-        const RefreshToken& refresh_token) const {
-        return static_cast<const DerivedProvider*>(this)
-            ->acquireTokensSilentlyImpl(refresh_token);
+    std::optional<Tokens> acquireSilently(const RefreshToken& token) const {
+        return static_cast<const DerivedProvider*>(this)->acquireSilentlyImpl(
+            token);
     }
 
     const DeviceCodeCredential& credentials() const {
         return device_code_credential_;
     }
 
-    const std::string& scopes() const { return scopes_; }
+    const Scopes& scopes() const { return scopes_; }
 
 private:
     DeviceCodeCredential device_code_credential_;
-    std::string scopes_;
+    Scopes scopes_;
 };
 
 }  // namespace teams::priv

--- a/lib/include/teams_lib/auth/TokenProvider.hpp
+++ b/lib/include/teams_lib/auth/TokenProvider.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <optional>
+#include <teams_lib/auth/DeviceCodeCredential.hpp>
+#include <teams_lib/auth/Tokens.hpp>
+#include <teams_lib/common.hpp>
+
+namespace teams::priv {
+
+template <typename DerivedProvider>
+class TokenProvider {
+public:
+    explicit TokenProvider(DeviceCodeCredential device_code_credential,
+                           std::string scopes)
+        : device_code_credential_{std::move(device_code_credential)},
+          scopes_{std::move(scopes)} {};
+
+    // TODO: change to std::expected on c++ version bump
+    std::optional<Tokens> acquireTokens() const {
+        return static_cast<const DerivedProvider*>(this)->acquireTokensImpl();
+    };
+
+    // TODO: change to std::expected on c++ version bump
+    std::optional<Tokens> acquireTokensSilently(
+        const RefreshToken& refresh_token) const {
+        return static_cast<const DerivedProvider*>(this)
+            ->acquireTokensSilentlyImpl(refresh_token);
+    }
+
+    const DeviceCodeCredential& credentials() const {
+        return device_code_credential_;
+    }
+
+    const std::string& scopes() const { return scopes_; }
+
+private:
+    DeviceCodeCredential device_code_credential_;
+    std::string scopes_;
+};
+
+}  // namespace teams::priv

--- a/lib/include/teams_lib/auth/TokenStorageProvider.hpp
+++ b/lib/include/teams_lib/auth/TokenStorageProvider.hpp
@@ -10,13 +10,12 @@ class TokenStorageProvider {
 public:
     TokenStorageProvider() = default;
 
-    std::optional<RefreshToken> loadRefreshToken() const {
-        return static_cast<const DerivedProvider*>(this)
-            ->loadRefreshTokenImpl();
+    std::optional<RefreshToken> load() const {
+        return static_cast<const DerivedProvider*>(this)->loadImpl();
     };
 
-    void storeRefreshToken(const RefreshToken& token) const {
-        static_cast<const DerivedProvider*>(this)->storeRefreshTokenImpl(token);
+    void store(const RefreshToken& token) const {
+        static_cast<const DerivedProvider*>(this)->storeImpl(token);
     };
 };
 }  // namespace teams::priv

--- a/lib/include/teams_lib/auth/TokenStorageProvider.hpp
+++ b/lib/include/teams_lib/auth/TokenStorageProvider.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <optional>
+#include <teams_lib/common.hpp>
+
+namespace teams::priv {
+
+template <typename DerivedProvider>
+class TokenStorageProvider {
+public:
+    TokenStorageProvider() = default;
+
+    std::optional<RefreshToken> loadRefreshToken() const {
+        return static_cast<const DerivedProvider*>(this)
+            ->loadRefreshTokenImpl();
+    };
+
+    void storeRefreshToken(const RefreshToken& token) const {
+        static_cast<const DerivedProvider*>(this)->storeRefreshTokenImpl(token);
+    };
+};
+}  // namespace teams::priv

--- a/lib/include/teams_lib/auth/Tokens.hpp
+++ b/lib/include/teams_lib/auth/Tokens.hpp
@@ -5,8 +5,8 @@
 namespace teams::priv {
 
 struct Tokens {
-    Token access_token;
-    std::optional<Token> refresh_token;
+    AccessToken access_token;
+    std::optional<RefreshToken> refresh_token;
 };
 
 }  // namespace teams::priv

--- a/lib/include/teams_lib/auth/Tokens.hpp
+++ b/lib/include/teams_lib/auth/Tokens.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <optional>
+#include <teams_lib/common.hpp>
+
+namespace teams::priv {
+
+struct Tokens {
+    Token access_token;
+    std::optional<Token> refresh_token;
+};
+
+}  // namespace teams::priv

--- a/lib/include/teams_lib/common.hpp
+++ b/lib/include/teams_lib/common.hpp
@@ -13,6 +13,7 @@ using Token = std::string;
 
 using RefreshToken = Token;
 using AccessToken = Token;
+using Scopes = std::string;
 
 using ID = std::string;
 using URL = std::string;

--- a/lib/include/teams_lib/common.hpp
+++ b/lib/include/teams_lib/common.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <httplib.h>
+
+#include <vector>
+
+using HttpHeader = httplib::Headers;
+using HttpClient = httplib::Client;
+
+template <typename ResourceType>
+using Collection = std::vector<ResourceType>;
+
+using Token = std::string;
+
+using RefreshToken = Token;
+using AccessToken = Token;
+
+using ID = std::string;
+using URL = std::string;


### PR DESCRIPTION
Authentication using device code as primary source, storing refresh token for in-background token renewal.
Refresh token stored as plain text in file on device as PoC.
closes  #2 
closes  #15 
closes #16
closes #17 